### PR TITLE
Expire non-remembered user sessions after 4 hours

### DIFF
--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -1,10 +1,16 @@
+from datetime import timedelta
 from enum import Enum
 
-__all__ = ["RedisKeys", "make_redis_key"]
+__all__ = ["RedisKeys", "KEY_EXPIRE_TIME", "make_redis_key"]
+
+
+# Default expiry time for a key
+KEY_EXPIRE_TIME = timedelta(minutes=30, hours=2)
 
 
 class RedisKeys(Enum):
     UserSession = "user_session"
+    UserData = "user_data"
 
 
 def make_redis_key(primary_key: RedisKeys, *fields: str) -> str:

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -5,7 +5,7 @@ __all__ = ["RedisKeys", "KEY_EXPIRE_TIME", "make_redis_key"]
 
 
 # Default expiry time for a key
-KEY_EXPIRE_TIME = timedelta(minutes=30, hours=2)
+KEY_EXPIRE_TIME = timedelta(hours=4)
 
 
 class RedisKeys(Enum):

--- a/app/static/css/components/header.css
+++ b/app/static/css/components/header.css
@@ -7,6 +7,10 @@ header {
   @apply shadow-lg;
 }
 
+header .wordmark {
+  @apply text-center;
+}
+
 header .title {
   @apply inline;
   @apply text-white;

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -6,6 +6,6 @@
 <section>
   <h1>It looks like you can't see that!</h1>
   <p>Just because this is a lighthouse doesn't mean <em>everything</em> can be illuminated.</p>
-  <p>If you haven't already, you may trying to <a href="{{ url_for('root.index') }}">sign in</a> to see if you can see the light. 😉</p>
+  <p>If you haven't already, you may try to <a href="{{ url_for('root.index') }}">sign in</a> to see if you can see the light. 😉</p>
 </section>
 {% endblock %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% set page_title = 'Access Forbidden' %}
+{% set page_class = '403' %}
 
 {% block content %}
-<br>
-<h2 class="text-center">❗ You do not have the necessary permissions to see that item. ❗</h2>
-<br>
+<section>
+  <h1>It looks like you can't see that!</h1>
+  <p>Just because this is a lighthouse doesn't mean <em>everything</em> can be illuminated.</p>
+  <p>If you haven't already, you may trying to <a href="{{ url_for('root.index') }}">sign in</a> to see if you can see the light. 😉</p>
+</section>
 {% endblock %}

--- a/app/templates/errors/403.html
+++ b/app/templates/errors/403.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% set page_title = 'Access Forbidden' %}
-{% set page_class = '403' %}
+{% set page_class = 'error' %}
 
 {% block content %}
 <section>

--- a/app/views/root.py
+++ b/app/views/root.py
@@ -63,12 +63,13 @@ def campus_select():
 @root.route("/signout", methods=["GET"])
 @login_required
 def sign_out():
+    # Delete all of the user's keys in Redis
+    for key in redis_utils.RedisKeys:
+        redis_key = redis_utils.make_redis_key(key, current_user.username, "active")
+        redis_client.delete(redis_key)
+
     # Remove this user session and sign them out
     current_user.authenticated = False
-    redis_key = redis_utils.make_redis_key(
-        redis_utils.RedisKeys.UserSession, current_user.username, "active"
-    )
-    redis_client.delete(redis_key)
     logout_user()
     flash("You have been successfully signed out. Thank you for your service!", "info")
     return redirect(url_for("root.index"))

--- a/app/views/root.py
+++ b/app/views/root.py
@@ -33,14 +33,14 @@ def sign_in():
                 redis_utils.RedisKeys.UserSession, user.username, "active"
             )
 
-            # Set the user session to expire in 2.5 hours,
+            # Set the user session to expire in 3 hours,
             # BUT ONLY if the user doesn't want the login
             # to be remembered. In that case, just record the login
             if form.remember_me.data:
                 redis_client.set(redis_key, "true")
 
             else:
-                expire_time = (60 * 60) * 2.5
+                expire_time = (60 * 60) * 3
                 redis_client.setex(redis_key, expire_time, "true")
             return redirect(url_for("root.campus_select"))
 

--- a/app/views/root.py
+++ b/app/views/root.py
@@ -32,7 +32,16 @@ def sign_in():
             redis_key = redis_utils.make_redis_key(
                 redis_utils.RedisKeys.UserSession, user.username, "active"
             )
-            redis_client.set(redis_key, "true")
+
+            # Set the user session to expire in 2.5 hours,
+            # BUT ONLY if the user doesn't want the login
+            # to be remembered. In that case, just record the login
+            if form.remember_me.data:
+                redis_client.set(redis_key, "true")
+
+            else:
+                expire_time = (60 * 60) * 2.5
+                redis_client.setex(redis_key, expire_time, "true")
             return redirect(url_for("root.campus_select"))
 
         # If the login info was not valid, let the user know
@@ -47,7 +56,8 @@ def sign_in():
 @root.route("/campus-select")
 @login_required
 def campus_select():
-    return f"Welcome to Lighthouse, {current_user.username}!"
+    return f"""Welcome to Lighthouse, {current_user.username}!
+    <br><a href="/signout">sign out</a>"""
 
 
 @root.route("/signout", methods=["GET"])

--- a/app/views/root.py
+++ b/app/views/root.py
@@ -33,15 +33,9 @@ def sign_in():
                 redis_utils.RedisKeys.UserSession, user.username, "active"
             )
 
-            # Set the user session to expire in 3 hours,
-            # BUT ONLY if the user doesn't want the login
-            # to be remembered. In that case, just record the login
-            if form.remember_me.data:
-                redis_client.set(redis_key, "true")
-
-            else:
-                expire_time = (60 * 60) * 3
-                redis_client.setex(redis_key, expire_time, "true")
+            # Record the user session and set it to expire
+            # at the default expire time
+            redis_client.setex(redis_key, redis_utils.KEY_EXPIRE_TIME, "true")
             return redirect(url_for("root.campus_select"))
 
         # If the login info was not valid, let the user know


### PR DESCRIPTION
Fix #19.

@Normantowne ~~I chose 3 hours because the foodbank is open for 2 hours and users are present and working before and after. Ideally, there should be some notification that tells them they are about to be signed out with an option to extend it, but that will need to be planned out. Currently, this only happens for non-remembered logins. Perhaps the timeout should be extended to all logins?~~ Timeout is now 4 hours long and apply all the time.

@ryleegarrett I reworded the 403 (permission missing) page because I was tired of looking at an ugly page. See #20 for another example of how I'm setting the tone. Does it sound good to you?