### PR TITLE
Expose redis outside 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     container_name: lighthouse-redis
     restart: unless-stopped
     ports:
-      - 127.0.0.1:6379:6379
+      - 6379:6379
     networks:
       - lighthouse
 


### PR DESCRIPTION
Thanks to the lacking power of Windows 10 Home, I can't run Docker, so Redis needs to be opened up publicly so I can access it from my laptop.