### PR TITLE
Make Docker build run TailwindCSS production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 # 1. Build process for node-based tooling
 FROM node:alpine AS node-build
-RUN mkdir -p /app
-WORKDIR /app
 
 # Copy the required build files and CSS files
-COPY [ "package*.json", "postcss.config.js", "tailwind.config.js", "./" ]
-COPY ./app/static/css/ ./app/static/css/
+RUN mkdir -p /app
+COPY . /app
+WORKDIR /app
 
 # Install everything and build the CSS
-RUN npm install --quiet --production && \
-  npm run build:style
+RUN npm install --quiet --production && npm run build
 
 
 # 2. Build process for Python app
@@ -22,7 +20,7 @@ ENV TZ=America/New_York
 
 # Install whatever system packages we need
 # skipcq: DOK-DL3018
-RUN apk add --no-cache curl iputils nano tzdata
+# RUN apk add --no-cache curl iputils nano tzdata
 
 # Set up the app in the proper location
 RUN mkdir -p /app

--- a/app/static/css/components/inputs.css
+++ b/app/static/css/components/inputs.css
@@ -1,3 +1,4 @@
+/* purgecss start ignore */
 /* Generic input field styling */
 input,
 select {
@@ -32,3 +33,4 @@ select {
   width: 140px;
   text-align: left;
 } */
+/* purgecss end ignore */

--- a/app/static/css/components/simplepicker.css
+++ b/app/static/css/components/simplepicker.css
@@ -8,7 +8,7 @@
 .simplepicker-calender tbody .active::after,
 .simplepicker-calender tbody td:active::after {
   background-color: #041e42 !important;
-  padding-bottom: 5px;
+  @apply pb-1;
 }
 
 /* Cancel/OK button hover states */

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:style": "postcss app/static/css/style.css -o app/static/build/style.min.css",
     "watch:style": "chokidar tailwind.config.js app/static/css/**/*.css -c \"npm run build:style\"",
-    "build": "npm run build:style && cross-env NODE_ENV=production npm run build:style"
+    "build": "cross-env NODE_ENV=production npm run build:style"
   },
   "keywords": [],
   "author": "",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,8 @@ var process = require("process");
 const tailwindcss = require("tailwindcss");
 const autoprefixer = require("autoprefixer");
 const purgecss = require("@fullhuman/postcss-purgecss")({
-  content: ["./app/static/js/**/*.js", "./app/templates/**/*.html", "./app/templates/**/*.jinja2"]
+  content: ["./app/static/js/**/*.js", "./app/templates/**/*.html", "./app/templates/**/*.jinja2"],
+  css: ["./app/static/css/**/*.css"]
 });
 const cssnano = require("cssnano")({
   preset: "default",


### PR DESCRIPTION
Fixes #3.

This shrinks the final CSS file from > 1 MB to (currently) 4 kb, which is exactly what we want.